### PR TITLE
Build bare metal images with packer qemu chroot

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -141,16 +141,16 @@ pipeline {
                   }
 
                   withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws']]) {
-                    parent_image.inside("-v /var/run/docker.sock:/var/run/docker.sock --privileged " +
+                    parent_image.inside("-v /var/run/docker.sock:/var/run/docker.sock -v /lib/modules:/lib/modules " +
+                                        "-v /dev:/dev -v /boot:/boot --cap-add=ALL --privileged " +
                                         "--env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
                                         "--env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY") {
-                      def use_sudo = config['build_type'] == 'docker' ? 'sudo -E PYTHONPATH=$PYTHONPATH PATH=$PATH' : ''
                       sh("""#!/bin/bash
                             source \$BUNDLE_ROOT/ros1/setup.bash &&
-                            ${use_sudo} create_image --name ${image} --distribution ${distribution} \
-                            --apt-repo ${params.apt_repo - 's3://'} --release-track ${params.release_track} \
-                            --release-label ${params.release_label} --flavour ${testing_flavour} \
-                            --organization ${organization} ${params.deploy ? '--publish' : ''} \
+                            sudo -E PYTHONPATH=\$PYTHONPATH PATH=\$PATH create_image --name ${image} \
+                            --distribution ${distribution} --apt-repo ${params.apt_repo - 's3://'} \
+                            --release-track ${params.release_track} --release-label ${params.release_label} \
+                            --flavour ${testing_flavour} --organization ${organization} ${params.deploy ? '--publish' : ''} \
                             --docker-registry ${params.docker_registry} --rosdistro-path /rosdistro
                          """)
                     }

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -44,9 +44,11 @@ RUN apt-get update -qq && apt-get install -qqy \
     curl \
     gcc \
     iptables \
+    libguestfs-tools \
     lxc \
     openssh-client \
     unzip \
+    wget \
     xz-utils
 
 # Install Docker from Docker Inc. repositories.
@@ -60,12 +62,12 @@ RUN pip3 install \
     pytest-runner
 
 # Install packer
-RUN curl -sSL https://releases.hashicorp.com/packer/1.4.0/packer_1.4.0_linux_amd64.zip > packer.zip && \
+RUN curl -sSL https://releases.hashicorp.com/packer/1.4.1/packer_1.4.1_linux_amd64.zip > packer.zip && \
     unzip packer.zip -d /usr/local/bin && \
     rm packer.zip
-
-# Install qemu
-RUN apt update -qq && apt install --no-install-recommends -y qemu-system-x86 cloud-utils
+RUN curl -sSlL https://github.com/summerwind/packer-builder-qemu-chroot/releases/download/v1.1.0/packer-builder-qemu-chroot_linux_amd64.tar.gz > packer_qemu_chroot.tar.gz && \
+    tar xf packer_qemu_chroot.tar.gz && mv packer-builder-qemu-chroot /usr/local/bin/packer-builder-qemu-chroot && \
+    rm packer_qemu_chroot.tar.gz
 
 COPY tailor-image tailor-image
 RUN pip3 install -e tailor-image

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,9 +19,7 @@ install_requires =
     boto3 ==1.9.119
     catkin-pkg ==0.4.10
     Click ==7.0
-    docker ==3.7.0
     PyYaml ==3.13
-    psutil ==5.4.2
 packages =find:
 setup_requires =
     pytest-runner


### PR DESCRIPTION
Updates tailor-image to use the `qemu-chroot` packer builder in order to decrease the build time for bare metal images.

* Add permissions to the docker image to be able to load the nbd kernel module
* Uses sudo for all image building now
* Install necessary packages to the image to be able to handle images (e.g. resizing)