### PR TITLE
Pass the ubuntu distro to the builder

### DIFF
--- a/tailor_image/create_image.py
+++ b/tailor_image/create_image.py
@@ -51,6 +51,7 @@ def create_image(name: str, distribution: str, apt_repo: str, release_track: str
             '-var', f'image_name={image_name}',
             '-var', f'organization={organization}',
             '-var', f'ecr_server={ecr_server}',
+            '-var', f'os_version={distribution}',
             '-var', f'ecr_repository={ecr_repository}',
             '-var', f'aws_access_key={os.environ["AWS_ACCESS_KEY_ID"]}',
             '-var', f'aws_secret_key={os.environ["AWS_SECRET_ACCESS_KEY"]}'


### PR DESCRIPTION
Investigating [RST-2168](https://locusrobotics.atlassian.net/browse/RST-2168?atlOrigin=eyJpIjoiYmY2ZTExYTEwZGZhNDMyNGFiNzY1OTZkY2VhMmUzMzMiLCJwIjoiaiJ9) I've found that I've never passed the correct ubuntu distribution to the builder, so all of the docker images were being generated with the default (xenial) as the base.