### PR TITLE
Use datetime.now() to avoid duplicating invalidations

### DIFF
--- a/tailor_image/create_image.py
+++ b/tailor_image/create_image.py
@@ -160,7 +160,7 @@ def update_image_index(release_track, apt_repo, common_config, image_name):
                                                f'/{index_key}',
                                            ]
                                        },
-                                       'CallerReference':  datetime.date.today().strftime('%Y%m%d%H%M%S')
+                                       'CallerReference':  datetime.datetime.now().strftime('%Y%m%d%H%M%S')
                                    })
 
 


### PR DESCRIPTION
Right now if we run two builds on the same day, we will generate the same invalidation reference and will fail. Adding more granular timestamp should fix this.