### PR TITLE
Allow to use different distro for base image

### DIFF
--- a/tailor_image/create_image.py
+++ b/tailor_image/create_image.py
@@ -64,7 +64,7 @@ def create_image(name: str, distribution: str, apt_repo: str, release_track: str
 
     elif build_type == 'bare_metal' and publish:
         # Get information about base image
-        base_image = recipe[name]['base_image']
+        base_image = recipe[name]['base_image'].replace('$distribution', distribution)
 
         # Get base image
         base_image_local_path = '/tmp/' + base_image


### PR DESCRIPTION
Even though we've enabled building images for bionic, we are still using the same image (from `rosdistro/config/images.yaml`) for both.

Whit this PR , we replace the `$distribution` template on `images.yaml` with the correct ubuntu distribution.

Related PR: https://github.com/locusrobotics/rosdistro/pull/45