### PR TITLE
Don't source bundle, remove problematic env vars instead

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,8 +147,7 @@ pipeline {
                                         "--env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
                                         "--env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY") {
                       sh("""#!/bin/bash
-                            source \$BUNDLE_ROOT/${config['distro']}/setup.bash &&
-                            sudo -E PYTHONPATH=\$PYTHONPATH PATH=\$PATH create_image --name ${image} \
+                            sudo -E create_image --name ${image} \
                             --distribution ${distribution} --apt-repo ${params.apt_repo - 's3://'} \
                             --release-track ${params.release_track} --release-label ${params.release_label} \
                             --flavour ${testing_flavour} --organization ${organization} ${params.deploy ? '--publish' : ''} \


### PR DESCRIPTION
The issue was not that we're not sourcing, but because we were still using passing the `PYTHONPATH` and `PATH` which was only necessary if we were sourcing outside of the `create_image.py`. 

We still need to use `-E` in order to pass some of the env vars (e.g. `BUNDLE_ROOT`) to the script. I have a branch were I was trying to remove the need of `sudo` to run `create_image.py` , but never got to get it working properly.

I'm still not completely sure why it fails on master, but the one that's failing has a new file `/opt/locusrobotics/hotdog/dev/ros1/_local_setup_util_sh.py` which checks for the env vars and fails if they are not set, I think this is a colcon related change.

The one that's failing has the `20191017.050316bionic` bundle installed, the other has `20191016.215111bionic`