### PR TITLE
Use python 3 for ansible when building images

### DIFF
--- a/environment/ansible.cfg
+++ b/environment/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+interpreter_python: auto

--- a/environment/image_recipes/ami/ami.json
+++ b/environment/image_recipes/ami/ami.json
@@ -66,7 +66,7 @@
       "inline": [
           "sudo apt-add-repository multiverse",
           "sudo apt-get update",
-          "sudo apt-get install -yq python2.7 ec2-ami-tools",
+          "sudo apt-get install -yq ec2-ami-tools",
           "echo \"{{user `username`}} ALL=(ALL) NOPASSWD: ALL\" | sudo tee -a /etc/sudoers",
           "echo \"{{user `password`}}\n{{user `password`}}\" | sudo passwd {{user `username`}}"
       ]
@@ -81,6 +81,7 @@
         "{{ user `extra_arguments_ansible` }}",
         "-e bundle_track={{user `bundle_track`}}",
         "-e bundle_version={{user `bundle_version`}}",
+        "-e ansible_python_interpreter=/usr/bin/python3",
         "-v"
       ]
     }

--- a/environment/image_recipes/ami/ami.json
+++ b/environment/image_recipes/ami/ami.json
@@ -66,7 +66,7 @@
       "inline": [
           "sudo apt-add-repository multiverse",
           "sudo apt-get update",
-          "sudo apt-get install -yq ec2-ami-tools",
+          "sudo apt-get install -yq python ec2-ami-tools",
           "echo \"{{user `username`}} ALL=(ALL) NOPASSWD: ALL\" | sudo tee -a /etc/sudoers",
           "echo \"{{user `password`}}\n{{user `password`}}\" | sudo passwd {{user `username`}}"
       ]
@@ -81,7 +81,6 @@
         "{{ user `extra_arguments_ansible` }}",
         "-e bundle_track={{user `bundle_track`}}",
         "-e bundle_version={{user `bundle_version`}}",
-        "-e ansible_python_interpreter=/usr/bin/python3",
         "-v"
       ]
     }

--- a/environment/image_recipes/bare_metal/bare_metal.json
+++ b/environment/image_recipes/bare_metal/bare_metal.json
@@ -37,15 +37,8 @@
       "type": "shell",
       "inline": [
           "mv /etc/resolv.conf /etc/resolv.conf.old",
-          "echo \"nameserver 1.1.1.1\" > /etc/resolv.conf"
-      ]
-    },
-
-    {
-      "type": "shell",
-      "inline": [
-        "apt-get update && apt-get install -yq python",
-        "echo \"unnamedrobot\" > /etc/hostname"
+          "echo \"nameserver 1.1.1.1\" > /etc/resolv.conf",
+          "echo \"unnamedrobot\" > /etc/hostname"
       ]
     },
 
@@ -73,6 +66,7 @@
         "-e bundle_track={{user `bundle_track`}}",
         "-e bundle_version={{user `bundle_version`}}",
         "-e image_name={{user `image_name`}}",
+        "-e ansible_python_interpreter=/usr/bin/python3",
         "--inventory={{user `inventory`}}"
       ]
     },

--- a/environment/image_recipes/bare_metal/bare_metal.json
+++ b/environment/image_recipes/bare_metal/bare_metal.json
@@ -38,7 +38,8 @@
       "inline": [
           "mv /etc/resolv.conf /etc/resolv.conf.old",
           "echo \"nameserver 1.1.1.1\" > /etc/resolv.conf",
-          "echo \"unnamedrobot\" > /etc/hostname"
+          "echo \"unnamedrobot\" > /etc/hostname",
+          "apt-get update && apt-get install -yq python"
       ]
     },
 
@@ -66,7 +67,6 @@
         "-e bundle_track={{user `bundle_track`}}",
         "-e bundle_version={{user `bundle_version`}}",
         "-e image_name={{user `image_name`}}",
-        "-e ansible_python_interpreter=/usr/bin/python3",
         "--inventory={{user `inventory`}}"
       ]
     },

--- a/environment/image_recipes/docker/docker.json
+++ b/environment/image_recipes/docker/docker.json
@@ -87,6 +87,7 @@
         "-e bundle_track={{user `bundle_track`}}",
         "-e bundle_version={{user `bundle_version`}}",
         "-e bundle_flavour={{user `bundle_flavour`}}",
+        "-e ansible_python_interpreter=/usr/bin/python3",
         "-e ansible_host=default"
       ]
     },

--- a/environment/image_recipes/docker/docker.json
+++ b/environment/image_recipes/docker/docker.json
@@ -87,7 +87,6 @@
         "-e bundle_track={{user `bundle_track`}}",
         "-e bundle_version={{user `bundle_version`}}",
         "-e bundle_flavour={{user `bundle_flavour`}}",
-        "-e ansible_python_interpreter=/usr/bin/python3",
         "-e ansible_host=default"
       ]
     },

--- a/tailor_image/create_image.py
+++ b/tailor_image/create_image.py
@@ -43,11 +43,11 @@ def create_image(name: str, distribution: str, apt_repo: str, release_track: str
     try:
         package = recipe[name]['package']
         provision_file = recipe[name]['provision_file']
-        env['ANSIBLE_CONFIG'] = find_package(package, 'ansible.cfg', env)
     except KeyError:
         package = '/tailor-image'
         provision_file = f'{build_type}.yaml'
 
+    env['ANSIBLE_CONFIG'] = find_package(package, 'ansible.cfg', env)
     template_path = f'/tailor-image/environment/image_recipes/{build_type}/{build_type}.json'
     provision_file_path = find_package(package, 'playbooks/' + provision_file, env)
 


### PR DESCRIPTION
Force ansible to use python3 so we don't need to install python2.7 to deploy to images.

With the newly added simulation images, tailor was failing to deploy via anisble because the python executable wasn't found.

Tested via http://tailor.locusbots.io/blue/organizations/jenkins/ci%2Ftailor-image/detail/use-python3/6/pipeline 