### PR TITLE
Allow select ubuntu distros to build for each image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,8 +127,15 @@ pipeline {
       steps {
         script {
           def jobs = [:]
-          distributions.each { distribution ->
-            jobs << images_config.collectEntries { image, config ->
+          images_config.each { image, config ->
+            def tmp_distributions = distributions.clone()
+
+            // If `os_versions` is not configured, default to build for all distros
+            if (config['os_versions']) {
+              tmp_distributions.retainAll(config['os_versions'])
+            }
+
+            jobs << tmp_distributions.collectEntries { distribution ->
               ["${image}-${distribution}", { node {
                 try {
                   dir('tailor-image') {

--- a/tailor_image/create_image.py
+++ b/tailor_image/create_image.py
@@ -77,7 +77,7 @@ def create_image(name: str, distribution: str, apt_repo: str, release_track: str
         if not publish:
             extra_vars += ['-except', 'publish']
 
-    elif build_type == 'bare_metal' and publish and distribution == 'xenial':
+    elif build_type == 'bare_metal' and publish:
         # Get information about base image
         base_image = recipe[name]['base_image'].replace('$distribution', distribution)
 
@@ -137,7 +137,7 @@ def create_image(name: str, distribution: str, apt_repo: str, release_track: str
     run_command(command, env=env)
 
     # TODO(gservin): If we build more that one bare metal image at the same time, we can have a race condition here
-    if build_type == 'bare_metal' and publish and distribution == 'xenial':
+    if build_type == 'bare_metal' and publish:
         update_image_index(release_track, apt_repo, common_config, image_name)
 
 


### PR DESCRIPTION
Allow setting for which ubuntu distros we want to build each image, this will require a new filed on the `config/images.yaml` in rosdistro using the following format `distros: ['xenial', 'bionic']`