### PR TITLE
Remove old images before starting building new ones

### DIFF
--- a/tailor_image/__init__.py
+++ b/tailor_image/__init__.py
@@ -15,9 +15,9 @@ def find_package(package: str, path: str, env):
     return path
 
 
-def run_command(cmd, *args, **kwargs):
+def run_command(cmd, check=True, *args, **kwargs):
     print(' '.join(cmd), file=sys.stderr)
-    return subprocess.run(cmd, check=True, *args, **kwargs)
+    return subprocess.run(cmd, check=check, *args, **kwargs)
 
 
 def source_file(path):


### PR DESCRIPTION
This should fix an old issue that we haven't seen in a while as well as prevent a new issue we've seen when building a bot image after a build has failed (See https://locusrobotics.atlassian.net/browse/RST-2386)