### PR TITLE
Support multi-os builds of bare metal images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,8 +128,8 @@ pipeline {
             def tmp_distributions = distributions.clone()
 
             // If `os_versions` is not configured, default to build for all distros
-            if (config['os_versions']) {
-              tmp_distributions.retainAll(config['os_versions'])
+            if (config.containsKey('os_versions')) {
+              tmp_distributions = config['os_versions'].findAll { it in distributions }
             }
 
             jobs << tmp_distributions.collectEntries { distribution ->
@@ -151,11 +151,17 @@ pipeline {
                                         "--env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
                                         "--env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY") {
                       sh("""#!/bin/bash
-                            sudo -E create_image --name ${image} \
-                            --distribution ${distribution} --apt-repo ${params.apt_repo - 's3://'} \
-                            --release-track ${params.release_track} --release-label ${params.release_label} \
-                            --flavour ${testing_flavour} --organization ${organization} ${params.deploy ? '--publish' : ''} \
-                            --docker-registry ${params.docker_registry} --rosdistro-path /rosdistro
+                            sudo -E create_image \
+                            --name ${image} \
+                            --distribution ${distribution} \
+                            --apt-repo ${params.apt_repo - 's3://'} \
+                            --release-track ${params.release_track} \
+                            --release-label ${params.release_label} \
+                            --flavour ${testing_flavour} \
+                            --organization ${organization} \
+                            --docker-registry ${params.docker_registry} \
+                            --rosdistro-path /rosdistro \
+                            ${params.deploy ? '--publish' : ''}
                          """)
                     }
                   }

--- a/tailor_image/create_image.py
+++ b/tailor_image/create_image.py
@@ -155,7 +155,10 @@ def update_image_index(release_track, apt_repo, common_config, image_name):
     {
       "<release_label>": {
         "<flavour>": {
-          "version": "<organization>_<flavour>_<distribution>_<release_label>_<date>",
+          "distribution": {
+            "<distribution>": "<organization>_<flavour>_<distribution>_<release_label>_<date>",
+            ...
+          },
           "checksums": {
             "<organization>_<flavour>_<distribution>_<release_label>_<date>": "<md5sum_of_image>",
           }
@@ -175,13 +178,13 @@ def update_image_index(release_track, apt_repo, common_config, image_name):
         try:
             lock.get()
         except botocore.exceptions.ClientError as error:
-            if error.response['Error']['Code'] == 'NosuchKey':
+            if error.response['Error']['Code'] == 'NoSuchKey':
                 lock.put(Body='')
                 break
 
     json.load_s3 = lambda f: json.load(s3_bucket.Object(key=f).get()['Body'])
     json.dump_s3 = lambda obj, f: s3_bucket.Object(key=f).put(Body=json.dumps(obj, indent=2))
-    _, flavour, _, release_label, _ = image_name.split('_')
+    _, flavour, distribution, release_label, _ = image_name.split('_')
 
     # Read checksum from generated file
     with open(f'/tmp/{image_name}', 'r') as checksum_file:
@@ -191,7 +194,9 @@ def update_image_index(release_track, apt_repo, common_config, image_name):
     base_data = {
         release_label: {
             flavour: {
-                'version': image_name,
+                'distributions': {
+                    distribution: image_name
+                },
                 'checksums': {
                     image_name: checksum
                 }
@@ -208,7 +213,7 @@ def update_image_index(release_track, apt_repo, common_config, image_name):
             data[release_label][flavour] = base_data[release_label][flavour]
         else:
             # If release_label and flavour already exists, update the image and add checksum
-            data[release_label][flavour]['version'] = image_name
+            data[release_label][flavour]['distributions'][distribution] = image_name
             data[release_label][flavour]['checksums'][image_name] = checksum
     except botocore.exceptions.ClientError as error:
         # If file doesn't exists, we'll create a new one

--- a/tailor_image/create_image.py
+++ b/tailor_image/create_image.py
@@ -149,6 +149,22 @@ def create_image(name: str, distribution: str, apt_repo: str, release_track: str
 
 
 def update_image_index(release_track, apt_repo, common_config, image_name):
+    """Updates the index file used to track bare metal images
+
+    Current format:
+    {
+      "<release_label>": {
+        "<flavour>": {
+          "version": "<organization>_<flavour>_<distribution>_<release_label>_<date>",
+          "checksums": {
+            "<organization>_<flavour>_<distribution>_<release_label>_<date>": "<md5sum_of_image>",
+          }
+        },
+        "<flavour_2>": {
+        }
+      }
+    }
+    """
     index_key = release_track + '/images/index'
     s3_bucket = boto3.resource("s3").Bucket(apt_repo)
 
@@ -159,37 +175,47 @@ def update_image_index(release_track, apt_repo, common_config, image_name):
         try:
             lock.get()
         except botocore.exceptions.ClientError as error:
-            if error.response['Error']['Code'] == 'NoSuchKey':
+            if error.response['Error']['Code'] == 'NosuchKey':
                 lock.put(Body='')
                 break
 
-    json.load_s3 = lambda f: json.load(s3_bucket.Object(key=f).get()["Body"])
+    json.load_s3 = lambda f: json.load(s3_bucket.Object(key=f).get()['Body'])
     json.dump_s3 = lambda obj, f: s3_bucket.Object(key=f).put(Body=json.dumps(obj, indent=2))
-    _, _, distribution, release_label, _ = image_name.split('_')
+    _, flavour, _, release_label, _ = image_name.split('_')
 
     # Read checksum from generated file
     with open(f'/tmp/{image_name}', 'r') as checksum_file:
         checksum = checksum_file.read().replace('\n', '').split(' ')[0]
     os.remove(f'/tmp/{image_name}')
 
-    data = {'latest': {release_label: {distribution: ''}}}
+    base_data = {
+        release_label: {
+            flavour: {
+                'version': image_name,
+                'checksums': {
+                    image_name: checksum
+                }
+            }
+        }
+    }
 
+    data = {}
     try:
         data = json.load_s3(index_key)
+        if release_label not in data:
+            data[release_label] = base_data[release_label]
+        elif flavour not in data[release_label]:
+            data[release_label][flavour] = base_data[release_label][flavour]
+        else:
+            # If release_label and flavour already exists, update the image and add checksum
+            data[release_label][flavour]['version'] = image_name
+            data[release_label][flavour]['checksums'][image_name] = checksum
     except botocore.exceptions.ClientError as error:
         # If file doesn't exists, we'll create a new one
-        if error.response['Error']['Code'] == "404":
-            pass
+        if error.response['Error']['Code'] == 'NoSuchKey':
+            data = base_data
 
-    # Update latest image
-    if release_label not in data['latest']:
-        data['latest'][release_label] = {distribution: image_name}
-    else:
-        data['latest'][release_label][distribution] = image_name
-
-    # Add checksum for new image
-    data[image_name] = checksum
-
+    # Write data to index file
     json.dump_s3(data, index_key)
 
     # Invalidate image index cache


### PR DESCRIPTION
A couple of changes to support building bare metal images for multiple OS

1. Changed index file format in order to support multiple flavours of bare metal images. The new format is
```
"<release_label>": {
  "<flavour>": {
    "version": "<organization>_<flavour>_<distribution>_<release_label>_<date>",
    "checksums": {
      "<organization>_<flavour>_<distribution>_<release_label>_<date>": "<md5sum_of_image>",
    }
  },
  "<flavour_2>": {
    ...
  }
}
```
2. Prevent race condition on the index file when building more than one bare metal image
3. Set the default image for the index to be the first one defined in the config file

