### PR TITLE
Wait until cloud-init finished runing before doing anything else

### DIFF
--- a/environment/image_recipes/ami/ami.json
+++ b/environment/image_recipes/ami/ami.json
@@ -64,6 +64,13 @@
     {
       "type": "shell",
       "inline": [
+          "while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 1; done"
+      ]
+    },
+
+    {
+      "type": "shell",
+      "inline": [
           "sudo apt-add-repository multiverse",
           "sudo apt-get update",
           "sudo apt-get install -yq python ec2-ami-tools",

--- a/environment/image_recipes/bare_metal/bare_metal.json
+++ b/environment/image_recipes/bare_metal/bare_metal.json
@@ -39,7 +39,7 @@
           "mv /etc/resolv.conf /etc/resolv.conf.old",
           "echo \"nameserver 1.1.1.1\" > /etc/resolv.conf",
           "echo \"unnamedrobot\" > /etc/hostname",
-          "apt-get update && apt-get install -yq python sudo openssl"
+          "apt-get update && apt-get install -yq python sudo openssl openssh-server"
       ]
     },
 


### PR DESCRIPTION
Add recommended step when building AMI with packer from the documentation https://www.packer.io/docs/other/debugging.html#issues-installing-ubuntu-packages. This makes sure cloud-init has finished running before doing anything else.