### PR TITLE
Install awscli in ami

### DIFF
--- a/environment/image_recipes/ami/ami.json
+++ b/environment/image_recipes/ami/ami.json
@@ -74,7 +74,9 @@
       "inline": [
           "sudo apt-add-repository multiverse",
           "sudo apt-get update",
-          "sudo apt-get install -yq python ec2-ami-tools",
+          "sudo apt-get install -yq python ec2-ami-tools awscli",
+          "sudo aws configure set s3.signature_version s3v4",
+          "sudo sed -i 's/preserve_hostname: false/preserve_hostname: true/g' /etc/cloud/cloud.cfg",
           "echo \"{{user `username`}} ALL=(ALL) NOPASSWD: ALL\" | sudo tee -a /etc/sudoers",
           "echo \"{{user `password`}}\n{{user `password`}}\" | sudo passwd {{user `username`}}"
       ]


### PR DESCRIPTION
Installing this in the AMI instead of at runtime has two benefits but only if it makes sense.
1. faster startup
2. more reliable