### PR TITLE
Make sure we set the correct home directory for image creation

### DIFF
--- a/environment/playbooks/bare_metal.yaml
+++ b/environment/playbooks/bare_metal.yaml
@@ -1,6 +1,8 @@
 ---
 - name: Provision a single robot image
   hosts: "/mnt/bare_metal"
+  environment:
+    HOME: "/home/{{ ansible_user }}"
   tasks:
   - name: Install desired packages
     apt:


### PR DESCRIPTION
Finally found out what the problem is. Apparently, the chrooot plugin doesn't clear the environment variables when it starts running, so they get passed into the chroot, setting the `HOME` to `/home/tailor` inside the chroot environment (because the script runs as tailor) 

I'm not very familiar with go, but will probably take a look at the code to see if I can find an obvious place where we can clear this.

For now, the easiest fix is to set the correct value for `HOME` in the playbook directly.