### PR TITLE
Add timeout when waiting for index to be  unlocked

### DIFF
--- a/tailor_image/__init__.py
+++ b/tailor_image/__init__.py
@@ -42,7 +42,9 @@ def tag_file(client, bucket, key, tag_key, tag_value):
 
 def wait_for_index(client, bucket, key):
     # Wait until file is not locket to avoid race condition
-    random.seed(datetime.now())
+    start_time = datetime.now()
+    random.seed(start_time)
+    timeout = 300 + random.random() * 300  # random timeout from 5 to 10 minutes
     while True:
         try:
             time.sleep(random.random()*5.0)
@@ -54,6 +56,9 @@ def wait_for_index(client, bucket, key):
                     tag_file(client, bucket, key, 'Lock', 'True')
                     break
                 elif tag['Key'] == 'Lock' and tag['Value'] == 'True':
+                    # If timeout is reached, allow writing to index
+                    if datetime.now() - start_time >= timeout:
+                        break
                     time.sleep(2.)
             else:
                 continue


### PR DESCRIPTION
When we create images, we Lock the index file to prevent other image building processes to write to it at the same time. Sometimes, when the build fails at the right time, we can skip clearing the `Lock` tag, thus preventing other processes to finish the image building process. This adds a timeout between 5-10 minutes after which, it should be safe to just write to the index file