### PR TITLE
Add lxd build type

### DIFF
--- a/environment/image_recipes/lxd/lxd.json
+++ b/environment/image_recipes/lxd/lxd.json
@@ -101,16 +101,29 @@
           "qemu-img convert images/{{user `image_name`}}.qcow2 images/{{user `image_name`}}.raw",
           "rm -f images/{{user `image_name`}}.qcow2",
 
+          "echo 'Mounting image'",
+          "mkdir -p $(pwd)/rootfs",
+          "echo $(pwd)",
+          "loop_device=$(sudo losetup -f -P --show images/{{user `image_name`}}.raw)",
+          "echo 'loop_device = '$loop_device",
+          "mount ${loop_device}p1 $(pwd)/rootfs",
+
+          "echo 'Creating metadata file'",
+          "echo \"architecture: x86_64\ncreation_date: $(date +%s)\nproperties:\n  description: {{user `organization`}} {{user `image_name`}} LXD image\n  os: Ubuntu\n  release: {{user `distribution`}}\" > $(pwd)/metadata.yaml",
+
           "echo 'Compressing generated image...'",
-          "xz -k images/{{user `image_name`}}.raw -c --verbose --threads=0 > images/{{user `image_name`}}.raw.xz",
+          "tar -czf images/{{user `image_name`}}.tar.gz rootfs metadata.yaml",
           "rm -f images/{{user `image_name`}}.raw",
 
           "echo 'Uploading compressed image to S3...'",
-          "aws s3 cp images/{{user `image_name`}}.raw.xz s3://{{user `s3_bucket`}}/{{user `bundle_version`}}/images/",
-          "md5sum images/{{user `image_name`}}.raw.xz > /tmp/{{user `image_name`}}",
-          "rm -f images/{{user `image_name`}}.raw.xz",
+          "aws s3 cp images/{{user `image_name`}}.tar.gz s3://{{user `s3_bucket`}}/{{user `bundle_version`}}/images/",
+          "md5sum images/{{user `image_name`}}.tar.gz > /tmp/{{user `image_name`}}",
+          "rm -f images/{{user `image_name`}}.tar.gz",
 
           "echo 'Removing generated images...'",
+          "umount -l $(pwd)/rootfs",
+          "losetup -d ${loop_device}",
+          "rm -rf metadata.yaml",
           "rm -rf images"
       ]
     }

--- a/environment/playbooks/lxd.yaml
+++ b/environment/playbooks/lxd.yaml
@@ -1,0 +1,13 @@
+---
+- name: Provision a single robot image
+  hosts: "/mnt/bare_metal"
+  environment:
+    HOME: "/home/{{ ansible_user }}"
+  tasks:
+  - name: Install desired packages
+    apt:
+      pkg: "{{ item }}"
+      state: present
+    with_items:
+      - vim
+    become: true

--- a/tailor_image/create_image.py
+++ b/tailor_image/create_image.py
@@ -91,7 +91,7 @@ def create_image(name: str, distribution: str, apt_repo: str, release_track: str
         # Make sure we remove old containers before creting new ones
         run_command(['docker', 'rm', '-f', 'default'], check=False)
 
-    elif build_type == 'bare_metal' and publish:
+    elif build_type in ['bare_metal', 'lxd'] and publish:
         # Get information about base image
         base_image = recipe[name]['base_image'].replace('$distribution', distribution)
 
@@ -133,6 +133,7 @@ def create_image(name: str, distribution: str, apt_repo: str, release_track: str
             '-var', f'image_name={image_name}',
             '-var', f's3_bucket={apt_repo}',
             '-var', f'iso_image={base_image_local_path}',
+            '-var', f'distribution={distribution}'
         ]
 
         # Make sure to clean old image builds
@@ -176,7 +177,7 @@ def create_image(name: str, distribution: str, apt_repo: str, release_track: str
 
     run_command(command, env=env, cwd='/tmp')
 
-    if build_type == 'bare_metal' and publish:
+    if build_type in ['bare_metal', 'lxd'] and publish:
         update_image_index(release_label, apt_repo, common_config, image_name)
 
 


### PR DESCRIPTION
This adds a separated `lxd` build type to tailor-image that creates an lxc (should I rename it to lxc?) image from the bare_metal one. The recipe is the same as the `bare_metal` one but instead of compressing the image with xz, it mounts it, creates a .tar.gz file in the format that lxc expects.