### PR TITLE
Fix permissions for lxd images as well

### DIFF
--- a/environment/image_recipes/bare_metal/bare_metal.json
+++ b/environment/image_recipes/bare_metal/bare_metal.json
@@ -84,6 +84,8 @@
 
           "echo 'Add image version file to image'",
           "echo '{\"active_version\": \"{{ user `image_name` }}\"}' | tee -a /home/{{ user `username` }}/.ota.json",
+
+          "echo 'Fix permissions in the home directory'",
           "chown -R {{ user `username` }}:{{ user `username` }} /home/{{ user `username` }}",
 
           "echo 'Remove unused space on the image'",

--- a/environment/image_recipes/lxd/lxd.json
+++ b/environment/image_recipes/lxd/lxd.json
@@ -84,7 +84,9 @@
 
           "echo 'Add image version file to image'",
           "echo '{\"active_version\": \"{{ user `image_name` }}\"}' | tee -a /home/{{ user `username` }}/.ota.json",
-          "chown {{ user `username` }}:{{ user `username` }} /home/{{ user `username` }}/.ota.json",
+
+          "echo 'Fix permissions in the home directory'",
+          "chown -R {{ user `username` }}:{{ user `username` }} /home/{{ user `username` }}",
 
           "echo 'Remove unused space on the image'",
           "dd if=/dev/zero of=/EMPTY bs=1M || true",


### PR DESCRIPTION
Turns out we also need to fix permissions for the lxd images, that's why wrangler images were still having the incorrect permissions.