### PR TITLE
Better way of resizing images

### DIFF
--- a/environment/image_recipes/bare_metal/bare_metal.json
+++ b/environment/image_recipes/bare_metal/bare_metal.json
@@ -17,6 +17,7 @@
     "inventory": "/mnt/bare_metal,",
 
     "s3_bucket": "tailor-artifacts",
+    "disk_size": "15",
 
     "iso_image": ""
   },
@@ -99,6 +100,13 @@
     {
       "type": "shell-local",
       "inline": [
+          "echo 'Resize image'",
+          "qemu-nbd -c /dev/nbd0 images/{{user `image_name`}}.qcow2",
+          "e2fsck -y -f /dev/nbd0p1",
+          "resize2fs /dev/nbd0p1 {{user `disk_size`}}G",
+          "qemu-nbd -d /dev/nbd0",
+          "qemu-img resize --shrink images/{{user `image_name`}}.qcow2 {{user `disk_size`}}G",
+
           "echo 'Converting image to RAW...'",
           "qemu-img convert images/{{user `image_name`}}.qcow2 images/{{user `image_name`}}.raw",
           "rm -f images/{{user `image_name`}}.qcow2",

--- a/tailor_image/create_image.py
+++ b/tailor_image/create_image.py
@@ -116,7 +116,7 @@ def create_image(name: str, distribution: str, apt_repo: str, release_track: str
         run_command(['modprobe', 'nbd'])
 
         # Resize image
-        run_command(['qemu-img', 'resize', base_image_local_path, f'+{disk_size}G'])
+        run_command(['qemu-img', 'resize', base_image_local_path, '30G'])
 
         # Copy image
         tmp_image = base_image_local_path.replace('disk1', 'disk1-resized')
@@ -133,7 +133,8 @@ def create_image(name: str, distribution: str, apt_repo: str, release_track: str
             '-var', f'image_name={image_name}',
             '-var', f's3_bucket={apt_repo}',
             '-var', f'iso_image={base_image_local_path}',
-            '-var', f'distribution={distribution}'
+            '-var', f'distribution={distribution}',
+            '-var', f'disk_size={disk_size}'
         ]
 
         # Make sure to clean old image builds


### PR DESCRIPTION
With this changes, we create a 30G image before deploying and we resize it to the desired size after we finish. I was able to build the jammy images and tested on my local NUC and the images work fine.