### PR TITLE
Add entrypoint to docker image

### DIFF
--- a/environment/image_recipes/docker/docker.json
+++ b/environment/image_recipes/docker/docker.json
@@ -1,5 +1,4 @@
 {
-
   "variables": {
     "image_name": "tailor_docker",
 
@@ -31,10 +30,13 @@
       "image": "{{user `os_name`}}:{{user  `os_version`}}",
       "commit": "true",
       "changes": [
-          "USER {{user `username`}}",
-          "LABEL tailor=\"{{user `type`}}_image\"",
-          "ENV BUNDLE_ROOT /opt/{{user `organization`}}/{{user `bundle_version`}}/{{user `bundle_flavour`}}",
-          "ENV LANG en_US.UTF-8"
+        "USER {{user `username`}}",
+        "LABEL tailor=\"{{user `type`}}_image\"",
+        "ENV BUNDLE_ROOT /opt/{{user `organization`}}/{{user `bundle_version`}}/{{user `bundle_flavour`}}",
+        "ENV LANG en_US.UTF-8",
+        "WORKDIR /home/{{user `username`}}",
+        "ENTRYPOINT [\"/bin/entrypoint.sh\"]",
+        "CMD [\"/bin/bash\"]"
       ],
       "run_command": [
         "-d",
@@ -52,14 +54,14 @@
     {
       "type": "shell",
       "environment_vars": [
-          "DEBIAN_FRONTEND=noninteractive",
-          "PYTHONUNBUFFERED=1",
-          "LANG=en_US.UTF-8"
+        "DEBIAN_FRONTEND=noninteractive",
+        "PYTHONUNBUFFERED=1",
+        "LANG=en_US.UTF-8"
       ],
       "inline": [
-          "apt-get update && apt-get install -yq python3 sudo locales ccache gnupg openssl",
-          "apt-get update && apt-get install -y tzdata",
-          "locale-gen en_US.UTF-8"
+        "apt-get update && apt-get install -yq python3 sudo locales ccache gnupg openssl",
+        "apt-get update && apt-get install -y tzdata",
+        "locale-gen en_US.UTF-8"
       ]
     },
 
@@ -103,6 +105,12 @@
         "echo \"yaml file:///etc/ros/rosdep/rosdep.yaml\" > /etc/ros/rosdep/sources.list.d/10-tailor.list",
         "su {{user `username`}} bash -c \"rosdep update\""
       ]
+    },
+
+    {
+      "type": "file",
+      "source": "entrypoint.sh",
+      "destination": "/bin/entrypoint.sh"
     }
   ],
 

--- a/environment/image_recipes/docker/entrypoint.sh
+++ b/environment/image_recipes/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source /etc/locus/setup.bash
+
+if [[ -v ROS1_WORKSPACE ]]; then
+  source $ROS1_WORKSPACE
+fi
+
+exec "$@"


### PR DESCRIPTION
With our docker image, when we run it we also need to source the workspaces which can lead to long commands and is difficult to get right with complex commands. 

For CI @kronos30 added a [ci-env.sh](https://github.com/locusrobotics/locus_deployment/blob/devel/locus_dev_scripts/scripts/ci-env.sh) file which is used as an entrypoint when running a command, e.g.

```bash
docker run -u 1000:1000 -v "${WORKSPACE}/${test}:${result_dir}:rw,z" --entrypoint "/opt/locusrobotics/hotdog/dev/ros1/bin/ci-env.sh" ${test_image} ${test}
```
https://github.com/locusrobotics/ci_integration_tests/blob/74904cf08ddd8159ff3bfec4a22edea27f8e6d49/Jenkinsfile#L84

If we set the `ENTRYPOINT` metadata we can avoid this extra line, while performing the normal action we need for the image to be useful.

Some other notes:
- As the entrypoint is only referenced here, I think it makes sense to have it defined here. It should be static across versions.
- I've tested the metadata locally using a Dockerfile, but I haven't tested the full pipeline using packer.
- I think this is valid for all uses, however I did try optionally sourcing the `ROS2_WORKSPACE` but I found I can't source both at the same time. Users of the image can still manually specify a different entrypoint to source ROS2.

To show the effect of this, I used this command:

Before:
```bash
$ docker run -it --rm  084758475884.dkr.ecr.us-east-1.amazonaws.com/locus-tailor:tailor-image-test-jammy-hotdog env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=0c6e47373d8e
TERM=xterm
BUNDLE_ROOT=/opt/locusrobotics/hotdog/dev
LANG=en_US.UTF-8
HOME=/home/locus
```

After:
```bash
$ docker run -it --rm  084758475884.dkr.ecr.us-east-1.amazonaws.com/locus-tailor:tailor-image-test-jammy-hotdog env
ROS_VERSION=1
LOCUS_RESPAWN_DELAY=5
PYTHONUNBUFFERED=1
PKG_CONFIG_PATH=/opt/locusrobotics/hotdog/dev/ros1/lib/x86_64-linux-gnu/pkgconfig:/opt/locusrobotics/hotdog/dev/ros1/lib/pkgconfig
ROS_PYTHON_VERSION=3
HOSTNAME=9e4fa6685e62
...
```

