### PR TITLE
Use absolute path for entryfile

### DIFF
--- a/environment/image_recipes/docker/docker.json
+++ b/environment/image_recipes/docker/docker.json
@@ -109,7 +109,7 @@
 
     {
       "type": "file",
-      "source": "/tailor-image/environment/image_recipes/docker/entrypoint.sh",
+      "source": "{{user `entrypoint_path`}}",
       "destination": "/bin/entrypoint.sh"
     }
   ],

--- a/environment/image_recipes/docker/docker.json
+++ b/environment/image_recipes/docker/docker.json
@@ -109,7 +109,7 @@
 
     {
       "type": "file",
-      "source": "entrypoint.sh",
+      "source": "/tailor-image/environment/image_recipes/docker/entrypoint.sh",
       "destination": "/bin/entrypoint.sh"
     }
   ],

--- a/tailor_image/create_image.py
+++ b/tailor_image/create_image.py
@@ -73,6 +73,7 @@ def create_image(name: str, distribution: str, apt_repo: str, release_track: str
     if build_type == 'docker':
         image_name = f'tailor-image-{name}-{distribution}-{release_label}'
         docker_registry_data = docker_registry.replace('https://', '').split('/')
+        entrypoint_path = f'/tailor-image/environment/image_recipes/docker/entrypoint.sh'
         ecr_server = docker_registry_data[0]
         ecr_repository = docker_registry_data[1]
         extra_vars = [
@@ -83,7 +84,8 @@ def create_image(name: str, distribution: str, apt_repo: str, release_track: str
             '-var', f'os_version={distribution}',
             '-var', f'ecr_repository={ecr_repository}',
             '-var', f'aws_access_key={os.environ["AWS_ACCESS_KEY_ID"]}',
-            '-var', f'aws_secret_key={os.environ["AWS_SECRET_ACCESS_KEY"]}'
+            '-var', f'aws_secret_key={os.environ["AWS_SECRET_ACCESS_KEY"]}',
+            '-var', f'entrypoint_path={entrypoint_path}'
         ]
 
         if not publish:


### PR DESCRIPTION
I assumed a relative path would be relative to the packer template but it is relative to the cwd.

When we run the command, we set this to [/tmp](https://github.com/locusrobotics/tailor-image/blob/21c2fcc64adb1bb8381078ddc69ca12f24720832/tailor_image/create_image.py#L180).

The absolute path is then [/tailor-image/environment/image_recipes/docker/entrypoint.sh](https://github.com/locusrobotics/tailor-image/blob/21c2fcc64adb1bb8381078ddc69ca12f24720832/tailor_image/create_image.py#L62) going by the `template_path`.

