### PR TITLE
Add retry block around docker build command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,17 +93,19 @@ pipeline {
           unstash(name: 'rosdistro')
           withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'tailor_aws'],
                             string(credentialsId: 'ansible_vault_password', variable: 'ANSIBLE_VAULT_PASS')]) {
-            parent_image = docker.build(parent_image_label,
-              "-f tailor-image/environment/Dockerfile --cache-from ${parent_image_label} " +
-              "--build-arg APT_REPO=${params.apt_repo} " +
-              "--build-arg APT_REGION=${params.apt_region} " +
-              "--build-arg RELEASE_LABEL=${params.release_label} " +
-              "--build-arg RELEASE_TRACK=${params.release_track} " +
-              "--build-arg FLAVOUR=${testing_flavour} " +
-              "--build-arg ORGANIZATION=${organization} " +
-              "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
-              "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY " +
-              "--build-arg ANSIBLE_VAULT_PASS=$ANSIBLE_VAULT_PASS .")
+            retry(params.retries as Integer) {
+              parent_image = docker.build(parent_image_label,
+                "-f tailor-image/environment/Dockerfile --cache-from ${parent_image_label} " +
+                "--build-arg APT_REPO=${params.apt_repo} " +
+                "--build-arg APT_REGION=${params.apt_region} " +
+                "--build-arg RELEASE_LABEL=${params.release_label} " +
+                "--build-arg RELEASE_TRACK=${params.release_track} " +
+                "--build-arg FLAVOUR=${testing_flavour} " +
+                "--build-arg ORGANIZATION=${organization} " +
+                "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
+                "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY " +
+                "--build-arg ANSIBLE_VAULT_PASS=$ANSIBLE_VAULT_PASS .")
+            }
           }
 
           parent_image.inside() {


### PR DESCRIPTION
Ocasionally, the stage of _Build tailor-image_ fails due to : 
```
 E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/a/argon2/libargon2-1_0%7e20171227-0.3_amd64.deb  Unable to connect to archive.ubuntu.com:80: [IP: 91.189.91.81 80]
[2025-05-14T06:30:53.710Z] #10 87.65 E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/l/lvm2/libdevmapper1.02.1_1.02.175-2.1ubuntu5_amd64.deb  Unable to connect to archive.ubuntu.com:80: [IP: 91.189.91.81 80]
[2025-05-14T06:30:53.710Z] #10 87.65 E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/c/cryptsetup/libcryptsetup12_2.4.3-1ubuntu1.3_amd64.deb  Unable to connect to 
```

This PR, wraps the docker build command with a retry block to try to mitigate this issue. 