### PR TITLE
Explicitly set ansible vault password file

### DIFF
--- a/environment/image_recipes/ami/ami.json
+++ b/environment/image_recipes/ami/ami.json
@@ -93,6 +93,7 @@
       "playbook_file": "{{user `playbook_file`}}",
       "groups": ["{{user `group`}}"],
       "extra_arguments": [
+        "--vault-password-file=/home/tailor/.vault_pass.txt",
         "{{ user `extra_arguments_ansible` }}",
         "-e bundle_track={{user `bundle_track`}}",
         "-e bundle_version={{user `bundle_version`}}",

--- a/environment/image_recipes/bare_metal/bare_metal.json
+++ b/environment/image_recipes/bare_metal/bare_metal.json
@@ -63,6 +63,7 @@
       "playbook_file": "{{user `playbook_file`}}",
       "extra_arguments": [
         "--connection=chroot",
+        "--vault-password-file=/home/tailor/.vault_pass.txt",
         "{{ user `extra_arguments_ansible` }}",
         "-e ansible_user={{user `username`}}",
         "-e organization={{user `organization`}}",

--- a/environment/image_recipes/docker/docker.json
+++ b/environment/image_recipes/docker/docker.json
@@ -83,6 +83,7 @@
       "playbook_file": "{{user `playbook_file`}}",
       "extra_arguments": [
         "--connection=docker",
+        "--vault-password-file=/home/tailor/.vault_pass.txt",
         "{{ user `extra_arguments_ansible` }}",
         "-e ansible_user={{user `username`}}",
         "-e organization={{user `organization`}}",

--- a/environment/image_recipes/lxd/lxd.json
+++ b/environment/image_recipes/lxd/lxd.json
@@ -62,6 +62,7 @@
       "playbook_file": "{{user `playbook_file`}}",
       "extra_arguments": [
         "--connection=chroot",
+        "--vault-password-file=/home/tailor/.vault_pass.txt",
         "{{ user `extra_arguments_ansible` }}",
         "-e ansible_user={{user `username`}}",
         "-e organization={{user `organization`}}",


### PR DESCRIPTION
Set the vault password file path in the packer recipe, instead of relying on the `ansible.cfg` file.