### PR TITLE
Create new support docker image 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -138,6 +138,12 @@ pipeline {
               tmp_distributions = config['os_versions'].findAll { it in distributions }
             }
 
+            // If `bundle_flavour` not defined, default to testing_flavour
+            def bundle_flavour = testing_flavour
+            if (config.containsKey('bundle_flavour')) {
+              bundle_flavour = config['bundle_flavour']
+            }
+
             jobs << tmp_distributions.collectEntries { distribution ->
               ["${image}-${distribution}", { node {
                 try {
@@ -164,7 +170,7 @@ pipeline {
                               --apt-repo ${params.apt_repo - 's3://'} \
                               --release-track ${params.release_track} \
                               --release-label ${params.release_label} \
-                              --flavour ${testing_flavour} \
+                              --flavour ${bundle_flavour} \
                               --organization ${organization} \
                               --docker-registry ${params.docker_registry} \
                               --rosdistro-path /rosdistro \


### PR DESCRIPTION
This PR gets a new tag  `bundle_flavour` from `rosdistro/config/images.yaml` to distinguish between `dev` and `support` bundle flavours. In that way, we can create two docker images:

- `dev` docker image containing the `dev` bundle 
- `support` docker image containing the `support` bundle 

The new `support` image is lighter ~2GB when doing `docker pull` compared to ~6GB of the `dev` image.

**Related PRs:**

- https://github.com/locusrobotics/locus_deployment/pull/1735
- https://github.com/locusrobotics/rosdistro/pull/283

**Jenkins pipeline that created the support image:**
- http://tailor.locusbots.io/blue/organizations/jenkins/ci%2Ftailor-image/detail/add-support-docker-images/2/pipeline
