### PR TITLE
Use docker cache while still updating apt packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,8 @@ pipeline {
                   "--build-arg ORGANIZATION=${organization} " +
                   "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
                   "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY " +
-                  "--build-arg ANSIBLE_VAULT_PASS=$ANSIBLE_VAULT_PASS .")
+                  "--build-arg ANSIBLE_VAULT_PASS=$ANSIBLE_VAULT_PASS " +
+                  "--build-arg BUILDKIT_INLINE_CACHE=1 .")
               }
             }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,8 @@ pipeline {
     string(name: 'apt_repo')
     string(name: 'apt_region', defaultValue: 'us-east-1')
     booleanParam(name: 'deploy', defaultValue: false)
+    booleanParam(name: 'invalidate_cache', defaultValue: false)
+    string(name: 'apt_refresh_key')
   }
 
   options {
@@ -96,6 +98,7 @@ pipeline {
                               string(credentialsId: 'ansible_vault_password', variable: 'ANSIBLE_VAULT_PASS')]) {
               retry(params.retries as Integer) {
                 parent_image = docker.build(parent_image_label,
+                  "${params.invalidate_cache ? '--no-cache ' : ''}" +
                   "-f tailor-image/environment/Dockerfile --cache-from ${parent_image_label} " +
                   "--build-arg APT_REPO=${params.apt_repo} " +
                   "--build-arg APT_REGION=${params.apt_region} " +
@@ -106,7 +109,8 @@ pipeline {
                   "--build-arg AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID " +
                   "--build-arg AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY " +
                   "--build-arg ANSIBLE_VAULT_PASS=$ANSIBLE_VAULT_PASS " +
-                  "--build-arg BUILDKIT_INLINE_CACHE=1 .")
+                  "--build-arg BUILDKIT_INLINE_CACHE=1 " +
+                  "--build-arg APT_REFRESH_KEY=${params.apt_refresh_key} .")
               }
             }
 

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -33,6 +33,8 @@ RUN apt-get update && apt-get install --no-install-recommends -y locales
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
+ARG APT_REFRESH_KEY
+
 # Let's start with some basic stuff.
 RUN echo "APT refresh key=${APT_REFRESH_KEY}"
 RUN apt-get update -qq && apt-get install --no-install-recommends -qqy \

--- a/environment/Dockerfile
+++ b/environment/Dockerfile
@@ -34,6 +34,7 @@ RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 
 # Let's start with some basic stuff.
+RUN echo "APT refresh key=${APT_REFRESH_KEY}"
 RUN apt-get update -qq && apt-get install --no-install-recommends -qqy \
     ansible \
     apt-transport-https \


### PR DESCRIPTION
This PR does the following: 
* makes use of Docker cache when re-building the Docker images
* exposes a new parameter named `invalidate_cache` to manually trigger the cache invalidation when needed
* uses a parameter named `apt_refresh_key` which is set to a combination of year and week number to trigger the cache invalidation once per week. This way the apt packages get updated at least once per week and we do not risk missing important updates. 